### PR TITLE
fixed import statements for index.gsp

### DIFF
--- a/grails-app/views/searchable/index.gsp
+++ b/grails-app/views/searchable/index.gsp
@@ -1,7 +1,8 @@
 <%@ page import="org.springframework.util.ClassUtils" %>
-<%@ page import="org.codehaus.groovy.grails.plugins.searchable.SearchableUtils" %>
-<%@ page import="org.codehaus.groovy.grails.plugins.searchable.lucene.LuceneUtils" %>
-<%@ page import="org.codehaus.groovy.grails.plugins.searchable.util.StringQueryUtils" %>
+<%@ page import="grails.plugin.searchable.internal.SearchableUtils" %>
+<%@ page import="grails.plugin.searchable.internal.lucene.LuceneUtils" %>
+<%@ page import="grails.plugin.searchable.internal.util.StringQueryUtils" %>
+
 <html>
   <head>
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">


### PR DESCRIPTION
Looks like SearchableUtils, LuceneUtils, and StringQueryUtils have been re-factored. I changed the imports at the top of the gsp to match the new package names. 
